### PR TITLE
Cube downloads fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>org.gbif.occurrence</groupId>
   <artifactId>download-query-tools</artifactId>
-  <version>2.0.9-SNAPSHOT</version>
+  <version>2.0.9-547-EXISTS-LAMBDA-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Download Query Tools</name>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
   <groupId>org.gbif.occurrence</groupId>
   <artifactId>download-query-tools</artifactId>
-  <version>2.0.9-547-EXISTS-LAMBDA-SNAPSHOT</version>
+  <version>2.0.9-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Download Query Tools</name>

--- a/src/main/java/org/gbif/occurrence/query/sql/HiveSqlOperatorTable.java
+++ b/src/main/java/org/gbif/occurrence/query/sql/HiveSqlOperatorTable.java
@@ -457,8 +457,7 @@ public class HiveSqlOperatorTable {
 
     // Utility functions
     // Support for lambda expressions used by higher-order functions like EXISTS(array, x -> x IN (...))
-    // We register a simple LAMBDA function and an EXISTS function that can accept a lambda
-    // as a second argument. The validator will transform `x -> expr` into `TAXON_LOOKUP(x, expr)`.
+    // The validator transforms `x -> expr` into `TAXON_LOOKUP(x, expr)`.
     final SqlFunction TAXON_LOOKUP =
         SqlBasicFunction.create(
             "TAXON_LOOKUP",

--- a/src/main/java/org/gbif/occurrence/query/sql/HiveSqlOperatorTable.java
+++ b/src/main/java/org/gbif/occurrence/query/sql/HiveSqlOperatorTable.java
@@ -458,14 +458,14 @@ public class HiveSqlOperatorTable {
     // Utility functions
     // Support for lambda expressions used by higher-order functions like EXISTS(array, x -> x IN (...))
     // We register a simple LAMBDA function and an EXISTS function that can accept a lambda
-    // as a second argument. The validator will transform `x -> expr` into `LAMBDA(x, expr)`.
-    final SqlFunction LAMBDA =
+    // as a second argument. The validator will transform `x -> expr` into `TAXON_LOOKUP(x, expr)`.
+    final SqlFunction TAXON_LOOKUP =
         SqlBasicFunction.create(
-            "LAMBDA",
+            "TAXON_LOOKUP",
             ReturnTypes.VARCHAR,
             OperandTypes.VARIADIC,
             SqlFunctionCategory.USER_DEFINED_FUNCTION);
-    additionalOperators.add(LAMBDA);
+    additionalOperators.add(TAXON_LOOKUP);
   }
 
   public List<SqlOperator> getAdditionalOperators() {

--- a/src/main/java/org/gbif/occurrence/query/sql/HiveSqlQuery.java
+++ b/src/main/java/org/gbif/occurrence/query/sql/HiveSqlQuery.java
@@ -98,13 +98,13 @@ public class HiveSqlQuery {
                 .withLineFolding(SqlWriterConfig.LineFolding.TALL);
 
     // Internal SQL
-    this.sql = node.toSqlString(sqlDialect).getSql();
+    this.sql = LambdaUtil.convertLambda(node.toSqlString(sqlDialect).getSql());
 
     // Nicely formatted SQL for the user
-    this.userSql = node.toSqlString(sqlWriterConfig).getSql();
+    this.userSql = LambdaUtil.convertLambda(node.toSqlString(sqlWriterConfig).getSql());
 
     if (node.getWhere() != null) {
-      this.sqlWhere = node.getWhere().toSqlString(sqlDialect).getSql();
+      this.sqlWhere = LambdaUtil.convertLambda(node.getWhere().toSqlString(sqlDialect).getSql());
     } else {
       this.sqlWhere = "1 = 1";
     }

--- a/src/main/java/org/gbif/occurrence/query/sql/HiveSqlValidator.java
+++ b/src/main/java/org/gbif/occurrence/query/sql/HiveSqlValidator.java
@@ -46,7 +46,6 @@ import org.apache.calcite.sql.SqlSelectKeyword;
 import org.apache.calcite.sql.SqlWriterConfig;
 import org.apache.calcite.sql.dialect.AnsiSqlDialect;
 import org.apache.calcite.sql.dialect.GbifHiveSqlDialect;
-import org.apache.calcite.sql.dialect.HiveSqlDialect;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
@@ -65,7 +64,7 @@ import org.slf4j.LoggerFactory;
 
 import static org.gbif.occurrence.query.sql.LambdaUtil.transformLambdaSyntax;
 
-class HiveSqlValidator {
+public class HiveSqlValidator {
   private static Logger LOG = LoggerFactory.getLogger(HiveSqlValidator.class);
 
   private static final Pattern SEMICOLON_END = Pattern.compile("[;\\s]*;\\s*$");

--- a/src/main/java/org/gbif/occurrence/query/sql/HiveSqlValidator.java
+++ b/src/main/java/org/gbif/occurrence/query/sql/HiveSqlValidator.java
@@ -63,7 +63,9 @@ import org.apache.calcite.util.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class HiveSqlValidator {
+import static org.gbif.occurrence.query.sql.LambdaUtil.transformLambdaSyntax;
+
+class HiveSqlValidator {
   private static Logger LOG = LoggerFactory.getLogger(HiveSqlValidator.class);
 
   private static final Pattern SEMICOLON_END = Pattern.compile("[;\\s]*;\\s*$");
@@ -298,67 +300,6 @@ public class HiveSqlValidator {
     }
   }
 
-  /**
-   * Replace occurrences of `<identifier> -> <expression>` with `LAMBDA(<identifier>, <expression>)`.
-   * This is a simple, local parser that handles nested parentheses in the expression.
-   */
-  private static String transformLambdaSyntax(String sql) {
-    StringBuilder sb = new StringBuilder(sql);
-    int idx = 0;
-    while ((idx = sb.indexOf("->", idx)) != -1) {
-      // find identifier to the left
-      int left = idx - 1;
-      // skip whitespace leftwards
-      while (left >= 0 && Character.isWhitespace(sb.charAt(left))) {
-        left--;
-      }
-      int endIdent = left;
-      // find start of identifier
-      while (left >= 0 && (Character.isLetterOrDigit(sb.charAt(left)) || sb.charAt(left) == '_')) {
-        left--;
-      }
-      int startIdent = left + 1;
-      if (startIdent > endIdent) {
-        // no valid identifier found, skip this occurrence
-        idx += 2;
-        continue;
-      }
-      String ident = sb.substring(startIdent, endIdent + 1);
-
-      // find start of expression to the right of ->
-      int right = idx + 2;
-      while (right < sb.length() && Character.isWhitespace(sb.charAt(right))) {
-        right++;
-      }
-
-      // parse until a comma or closing parenthesis at depth 0
-      int depth = 0;
-      int exprEnd = right;
-      while (exprEnd < sb.length()) {
-        char c = sb.charAt(exprEnd);
-        if (c == '(') {
-          depth++;
-        } else if (c == ')') {
-          if (depth == 0) {
-            break;
-          }
-          depth--;
-        } else if (c == ',' && depth == 0) {
-          break;
-        }
-        exprEnd++;
-      }
-
-      String expr = sb.substring(right, exprEnd).trim();
-
-      String replacement = "LAMBDA(" + ident + ", " + expr + ")";
-      sb.replace(startIdent, exprEnd, replacement);
-
-      // continue scanning after the replacement
-      idx = startIdent + replacement.length();
-    }
-    return sb.toString();
-  }
 
   public SqlDialect getDialect() {
     return dialect;

--- a/src/main/java/org/gbif/occurrence/query/sql/LambdaUtil.java
+++ b/src/main/java/org/gbif/occurrence/query/sql/LambdaUtil.java
@@ -1,0 +1,94 @@
+package org.gbif.occurrence.query.sql;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class LambdaUtil {
+
+    private static final Pattern LAMBDA_PATTERN = Pattern.compile(
+            "LAMBDA\\s*\\(\\s*([^,]+?)\\s*,\\s*(.*?)\\s*\\)",
+            Pattern.CASE_INSENSITIVE);
+
+    public static String convertLambda(String sql) {
+        Matcher matcher = LAMBDA_PATTERN.matcher(sql);
+        StringBuffer result = new StringBuffer();
+
+        while (matcher.find()) {
+            String variable = matcher.group(1).trim();
+            String expression = matcher.group(2).trim();
+
+            // Replace all occurrences of the variable with x
+            expression = expression.replaceAll(
+                    "\\b" + Pattern.quote(variable) + "\\b",
+                    "x");
+
+            matcher.appendReplacement(result,
+                    Matcher.quoteReplacement("x -> " + expression));
+        }
+
+        matcher.appendTail(result);
+        return result.toString();
+    }
+
+    /**
+     * Replace occurrences of `<identifier> -> <expression>` with `LAMBDA(<identifier>, <expression>)`.
+     * This is a simple, local parser that handles nested parentheses in the expression.
+     */
+    public static String transformLambdaSyntax(String sql) {
+        StringBuilder sb = new StringBuilder(sql);
+        int idx = 0;
+        while ((idx = sb.indexOf("->", idx)) != -1) {
+            // find identifier to the left
+            int left = idx - 1;
+            // skip whitespace leftwards
+            while (left >= 0 && Character.isWhitespace(sb.charAt(left))) {
+                left--;
+            }
+            int endIdent = left;
+            // find start of identifier
+            while (left >= 0 && (Character.isLetterOrDigit(sb.charAt(left)) || sb.charAt(left) == '_')) {
+                left--;
+            }
+            int startIdent = left + 1;
+            if (startIdent > endIdent) {
+                // no valid identifier found, skip this occurrence
+                idx += 2;
+                continue;
+            }
+            String ident = sb.substring(startIdent, endIdent + 1);
+
+            // find start of expression to the right of ->
+            int right = idx + 2;
+            while (right < sb.length() && Character.isWhitespace(sb.charAt(right))) {
+                right++;
+            }
+
+            // parse until a comma or closing parenthesis at depth 0
+            int depth = 0;
+            int exprEnd = right;
+            while (exprEnd < sb.length()) {
+                char c = sb.charAt(exprEnd);
+                if (c == '(') {
+                    depth++;
+                } else if (c == ')') {
+                    if (depth == 0) {
+                        break;
+                    }
+                    depth--;
+                } else if (c == ',' && depth == 0) {
+                    break;
+                }
+                exprEnd++;
+            }
+
+            String expr = sb.substring(right, exprEnd).trim();
+
+            String replacement = "LAMBDA(" + ident + ", " + expr + ")";
+            sb.replace(startIdent, exprEnd, replacement);
+
+            // continue scanning after the replacement
+            idx = startIdent + replacement.length();
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/gbif/occurrence/query/sql/LambdaUtil.java
+++ b/src/main/java/org/gbif/occurrence/query/sql/LambdaUtil.java
@@ -6,7 +6,7 @@ import java.util.regex.Pattern;
 class LambdaUtil {
 
     private static final Pattern LAMBDA_PATTERN = Pattern.compile(
-            "LAMBDA\\s*\\(\\s*([^,]+?)\\s*,\\s*(.*?)\\s*\\)",
+            "TAXON_LOOKUP\\s*\\(\\s*([^,]+?)\\s*,\\s*(.*?)\\s*\\)",
             Pattern.CASE_INSENSITIVE);
 
     public static String convertLambda(String sql) {
@@ -20,10 +20,10 @@ class LambdaUtil {
             // Replace all occurrences of the variable with x
             expression = expression.replaceAll(
                     "\\b" + Pattern.quote(variable) + "\\b",
-                    "x");
+                    "taxonkey");
 
             matcher.appendReplacement(result,
-                    Matcher.quoteReplacement("x -> " + expression));
+                    Matcher.quoteReplacement("taxonkey -> " + expression));
         }
 
         matcher.appendTail(result);
@@ -83,7 +83,7 @@ class LambdaUtil {
 
             String expr = sb.substring(right, exprEnd).trim();
 
-            String replacement = "LAMBDA(" + ident + ", " + expr + ")";
+            String replacement = "TAXON_LOOKUP(" + ident + ", " + expr + ")";
             sb.replace(startIdent, exprEnd, replacement);
 
             // continue scanning after the replacement

--- a/src/main/java/org/gbif/occurrence/query/sql/LambdaUtil.java
+++ b/src/main/java/org/gbif/occurrence/query/sql/LambdaUtil.java
@@ -9,7 +9,22 @@ class LambdaUtil {
             "TAXON_LOOKUP\\s*\\(\\s*([^,]+?)\\s*,\\s*(.*?)\\s*\\)",
             Pattern.CASE_INSENSITIVE);
 
+    /**
+     * Replaces occurrences of `TAXON_LOOKUP(<identifier>, <expression>)` with `<identifier> -> <expression>`.
+     * This is performed on the SQL after validation with calcite 1.35.0.
+     * @param sql
+     * @return
+     */
     public static String convertLambda(String sql) {
+
+        if (sql == null) {
+            return null;
+        }
+
+        if (!sql.contains("TAXON_LOOKUP")) {
+            return sql;
+        }
+
         Matcher matcher = LAMBDA_PATTERN.matcher(sql);
         StringBuffer result = new StringBuffer();
 
@@ -31,8 +46,8 @@ class LambdaUtil {
     }
 
     /**
-     * Replace occurrences of `<identifier> -> <expression>` with `LAMBDA(<identifier>, <expression>)`.
-     * This is a simple, local parser that handles nested parentheses in the expression.
+     * Replace occurrences of `<identifier> -> <expression>` with `TAXON_LOOKUP(<identifier>, <expression>)`.
+     * This enables validation with calcite 1.35.0.
      */
     public static String transformLambdaSyntax(String sql) {
         StringBuilder sb = new StringBuilder(sql);

--- a/src/test/java/org/gbif/occurrence/query/sql/HiveSqlQueryTest.java
+++ b/src/test/java/org/gbif/occurrence/query/sql/HiveSqlQueryTest.java
@@ -85,6 +85,32 @@ public class HiveSqlQueryTest {
         q.getUserSql());
   }
 
+  @Test
+  public void testExistsSql() throws Exception {
+    HiveSqlQuery q =
+            new HiveSqlQuery(hiveSqlValidator, "SELECT datasetKey from OCCURRENCE " +
+                    "WHERE EXISTS(classifications['uuid'], taxonkey -> taxonkey IN ('1','2'))");
+
+    String sql = q.getSql();
+
+    System.out.println(sql);
+  }
+
+  @Test
+  public void testDoubleExistsSql() throws Exception {
+    HiveSqlQuery q =
+            new HiveSqlQuery(hiveSqlValidator, "SELECT datasetKey from OCCURRENCE " +
+                    "WHERE " +
+                    "EXISTS(classifications['uuid'], taxonkey -> taxonkey IN ('1','2'))" +
+                    " OR " +
+                    "EXISTS(classifications['uuid'], taxonkey -> taxonkey IN ('3','4'))"
+            );
+
+    String sql = q.getSql();
+
+    System.out.println(sql);
+  }
+
   private static Stream<Arguments> provideSql() {
     return Stream.of(
         Arguments.of(

--- a/src/test/java/org/gbif/occurrence/query/sql/HiveSqlQueryTest.java
+++ b/src/test/java/org/gbif/occurrence/query/sql/HiveSqlQueryTest.java
@@ -90,10 +90,9 @@ public class HiveSqlQueryTest {
     HiveSqlQuery q =
             new HiveSqlQuery(hiveSqlValidator, "SELECT datasetKey from OCCURRENCE " +
                     "WHERE EXISTS(classifications['uuid'], taxonkey -> taxonkey IN ('1','2'))");
-
-    String sql = q.getSql();
-
-    System.out.println(sql);
+    assertEquals("SELECT datasetkey\n" +
+            "FROM occurrence\n" +
+            "WHERE EXISTS (occurrence.classifications['uuid'], taxonkey -> taxonkey IN ('1', '2'))", q.getSql());
   }
 
   @Test
@@ -105,10 +104,9 @@ public class HiveSqlQueryTest {
                     " OR " +
                     "EXISTS(classifications['uuid'], taxonkey -> taxonkey IN ('3','4'))"
             );
-
-    String sql = q.getSql();
-
-    System.out.println(sql);
+    assertEquals("SELECT datasetkey\n" +
+            "FROM occurrence\n" +
+            "WHERE EXISTS (occurrence.classifications['uuid'], taxonkey -> taxonkey IN ('1', '2')) OR EXISTS (occurrence.classifications['uuid'], taxonkey -> taxonkey IN ('3', '4'))", q.getSql());
   }
 
   private static Stream<Arguments> provideSql() {

--- a/src/test/java/org/gbif/occurrence/query/sql/HiveSqlValidatorTest.java
+++ b/src/test/java/org/gbif/occurrence/query/sql/HiveSqlValidatorTest.java
@@ -116,18 +116,23 @@ public class HiveSqlValidatorTest {
   @ParameterizedTest
   @MethodSource("provideStringsForExistsLambda")
   public void testValidateExistsSql(String sql)  throws Exception{
-    SqlSelect s = hiveSqlValidator.validate(sql);
-
-    String sqlOut = s.toSqlString(hiveSqlValidator.getDialect()).toString();
-
-    System.out.println(sqlOut);
+    hiveSqlValidator.validate(sql);
   }
 
   private static Stream<Arguments> provideStringsForExistsLambda() {
     return Stream.of(
             Arguments.of(
                     "SELECT datasetKey from OCCURRENCE " +
-                            "WHERE EXISTS(classifications['uuid'], taxonkey -> taxonkey IN ('1','2'))")
+                            "WHERE EXISTS(classifications['uuid'], taxonkey -> taxonkey IN ('1','2'))"),
+            Arguments.of(
+                    "SELECT datasetKey from OCCURRENCE " +
+                            "WHERE EXISTS(classifications['uuid'], taxonkey -> taxonkey IN ('1','2'))" +
+                            " OR EXISTS(classifications['uuid'], taxonkey -> taxonkey IN ('3','4'))"),
+            Arguments.of(
+                    "SELECT datasetKey from OCCURRENCE " +
+                            "WHERE EXISTS(classifications['uuid'], taxonkey -> taxonkey IN ('1','2'))" +
+                            " OR EXISTS(classifications['uuid'], taxonkey -> taxonkey IN ('3','4')) and year > 2000")
+
     );
   }
 

--- a/src/test/java/org/gbif/occurrence/query/sql/HiveSqlValidatorTest.java
+++ b/src/test/java/org/gbif/occurrence/query/sql/HiveSqlValidatorTest.java
@@ -113,6 +113,24 @@ public class HiveSqlValidatorTest {
     }
   }
 
+  @ParameterizedTest
+  @MethodSource("provideStringsForExistsLambda")
+  public void testValidateExistsSql(String sql)  throws Exception{
+    SqlSelect s = hiveSqlValidator.validate(sql);
+
+    String sqlOut = s.toSqlString(hiveSqlValidator.getDialect()).toString();
+
+    System.out.println(sqlOut);
+  }
+
+  private static Stream<Arguments> provideStringsForExistsLambda() {
+    return Stream.of(
+            Arguments.of(
+                    "SELECT datasetKey from OCCURRENCE " +
+                            "WHERE EXISTS(classifications['uuid'], taxonkey -> taxonkey IN ('1','2'))")
+    );
+  }
+
   private static Stream<Arguments> provideStringsForAllowedSql() {
     return Stream.of(
         Arguments.of(

--- a/src/test/java/org/gbif/occurrence/query/sql/TestOccurrenceTable.java
+++ b/src/test/java/org/gbif/occurrence/query/sql/TestOccurrenceTable.java
@@ -69,6 +69,10 @@ class TestOccurrenceTable extends AbstractTable {
     builder.add("checklistkey", SqlTypeName.CHAR);
     builder.add("taxonkey", SqlTypeName.CHAR);
     builder.add("scientificname", SqlTypeName.CHAR);
+    builder.add("classifications", typeFactory.createMapType(
+            typeFactory.createSqlType(SqlTypeName.VARCHAR),
+            typeFactory.createArrayType(typeFactory.createSqlType(SqlTypeName.VARCHAR), -1))
+    );
 
     RelDataTypeFactory tdf = new SqlTypeFactoryImpl(RelDataTypeSystem.DEFAULT);
     RelDataType varChar = tdf.createSqlType(SqlTypeName.VARCHAR);


### PR DESCRIPTION
Related to https://github.com/gbif/occurrence/issues/547

This ensures the text replacement of lambda expressions e.g.

```sql
EXISTS(classification['uuid'], x -> x IN ('N', 'P')
```

with a fake operator is reverted in the output SQL when users of the API use `HiveSqlQuery` to validate and parse the SQL.

I've reverted to keeping 1.35.0 as the difference in SQL output for versions 1.37.0, 1.38.0, and 1.39.0 of calcite all had major differences that could affect stability of our SQL API.

Its worth noting as well that `EXISTS` is a standard ANSI function which works differently to the Spark SQL `EXISTS` which takes a lambda expression. Overriding the version of `EXISTS` in the standard operator table is not straightforward.

This workaround is specifically tied to taxonomy so I've renamed the temporary fake operator used for validation to `TAXON_LOOKUP` but this should be exposed outside of this API.




